### PR TITLE
Exclude reserved bleacher from targets

### DIFF
--- a/falcon/Core/Inc/eaglesteward/game_entities.hpp
+++ b/falcon/Core/Inc/eaglesteward/game_entities.hpp
@@ -41,13 +41,17 @@ class Bleacher : public GameEntity {
 
     [[nodiscard]] std::array<GameEntity, 2> waypoints() const;
 
-    [[nodiscard]] bool in_building_area(const SizedArray<BuildingArea, 8> &building_areas) const;
+    // The 2 bleachers in the centre
+    [[nodiscard]] bool is_easy_central() const;
 
-    bool is_easy_central() const;
+    // The bleacher closest to the starting position, on the side of our robot
+    [[nodiscard]] bool is_easy_side(RobotColour colour) const;
 
-    bool is_easy_side(RobotColour colour) const;
+    // The reserved bleacher next to the backstage
+    [[nodiscard]] bool is_reserved(RobotColour colour) const;
 
-    bool is_next_to_backstage() const;
+    // The 4 bleachers next to the backstage
+    [[nodiscard]] bool is_next_to_backstage() const;
 };
 
 // Can class

--- a/falcon/Core/Src/eaglesteward/game_entities.cpp
+++ b/falcon/Core/Src/eaglesteward/game_entities.cpp
@@ -34,16 +34,6 @@ std::array<GameEntity, 2> Bleacher::waypoints() const {
     }};
 }
 
-bool Bleacher::in_building_area(const SizedArray<BuildingArea, 8> &building_areas) const {
-    for (const auto &building_area : building_areas) {
-        if (std::abs(x - building_area.x) < (building_area.span_x(false) + BLEACHER_WIDTH) / 2 &&
-            std::abs(y - building_area.y) < (building_area.span_y(false) + BLEACHER_WIDTH) / 2) {
-            return true;
-        }
-    }
-    return false;
-}
-
 bool Bleacher::is_easy_central() const {
     return floatEqual(y, 0.950f) && (floatEqual(x, FIELD_WIDTH_M - 1.100f) || floatEqual(x, 1.100f));
 }
@@ -51,6 +41,11 @@ bool Bleacher::is_easy_central() const {
 bool Bleacher::is_easy_side(const RobotColour colour) const {
     return floatEqual(y, 0.250f) &&
            (colour == RobotColour::Blue ? floatEqual(x, FIELD_WIDTH_M - 0.775f) : floatEqual(x, 0.775f));
+}
+
+bool Bleacher::is_reserved(const RobotColour colour) const {
+    return floatEqual(y, 1.725f) &&
+           (colour == RobotColour::Blue ? floatEqual(x, FIELD_WIDTH_M - 0.825f) : floatEqual(x, 0.825f));
 }
 
 bool Bleacher::is_next_to_backstage() const { return y >= 1.0f; }

--- a/falcon/Core/Src/eaglesteward/world.cpp
+++ b/falcon/Core/Src/eaglesteward/world.cpp
@@ -90,6 +90,11 @@ void World::enqueue_targets() {
         for (const auto &bleacher : bleachers_) {
             if (!bleacher.initial_position)
                 continue;
+
+            if (bleacher.is_reserved(RobotColour::Blue) && colour_ == RobotColour::Yellow ||
+                bleacher.is_reserved(RobotColour::Yellow) && colour_ == RobotColour::Blue)
+                continue;
+
             float value = 1.50f;
             if (bleacher.is_easy_side(colour_)) {
                 value = 0.00f;


### PR DESCRIPTION
@Thibault-Monnier Les bleachers du haut ne sont pas exclus à cause du champ d'obstacles. En fait ils sont là, mais invisibles à cause de leur valeur initiale élevée :
![image](https://github.com/user-attachments/assets/eabe4591-87cb-4d46-b21b-a8b2e145d764)
